### PR TITLE
jsdoc-to-markdown, next version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,57 +11,7 @@ npm install textlint-rule-helper
 ## Usage - API
 
 
-  <a name="module_textlint-rule-helper"></a>
-###textlint-rule-helper
-**Example**  
-```js
-var RuleHelper = require("textlint-rule-helper").RuleHelper;
-```
-
-* [textlint-rule-helper](#module_textlint-rule-helper)
-  * [class: ~RuleHelper](#module_textlint-rule-helper..RuleHelper)
-    * [new RuleHelper()](#new_module_textlint-rule-helper..RuleHelper_new)
-    * _instance_
-      * [.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>Array.&lt;TxtNode&gt;</code>
-      * [.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
-
-<a name="module_textlint-rule-helper..RuleHelper"></a>
-####class: textlint-rule-helper~RuleHelper
-
-* [class: ~RuleHelper](#module_textlint-rule-helper..RuleHelper)
-  * [new RuleHelper()](#new_module_textlint-rule-helper..RuleHelper_new)
-  * _instance_
-    * [.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>Array.&lt;TxtNode&gt;</code>
-    * [.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
-
-<a name="new_module_textlint-rule-helper..RuleHelper_new"></a>
-#####new RuleHelper()
-RuleHelper is helper class for textlint.
-
-<a name="module_textlint-rule-helper..RuleHelper#getParents"></a>
-#####ruleHelper.getParents(node) ⇒ <code>Array.&lt;TxtNode&gt;</code>
-Get parents of node.
-The parent nodes are returned in order from the closest parent to the outer ones.
-[node](node) is not contained in the results.
-
-| Param | Type | Description |
-| ----- | ---- | ----------- |
-| node | <code>TxtNode</code> | the node is start point. |
-
-<a name="module_textlint-rule-helper..RuleHelper#isChildNode"></a>
-#####ruleHelper.isChildNode(node, types) ⇒ <code>boolean</code>
-Return true if `node` is wrapped any one of node [types](types).
-
-| Param | Type | Description |
-| ----- | ---- | ----------- |
-| node | <code>TxtNode</code> | is target node |
-| types | <code>Array.&lt;string&gt;</code> | are wrapped target node |
-
-
-
-
-## Example
-
+  **Example**  
 A rule for [textlint](https://github.com/azu/textlint "textlint").
 
 ```js
@@ -81,6 +31,53 @@ module.exports = function (context) {
     return exports;
 }
 ```
+
+* [textlint-rule-helper](#module_textlint-rule-helper)
+  * [.RuleHelper](#module_textlint-rule-helper.RuleHelper) → <code>RuleHelper</code>
+  * [class: ~RuleHelper](#module_textlint-rule-helper..RuleHelper)
+    * [new RuleHelper()](#new_module_textlint-rule-helper..RuleHelper_new)
+    * _instance_
+      * [.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>[Array.&lt;TxtNode&gt;](https://github.com/azu/textlint)</code>
+      * [.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
+
+<a name="module_textlint-rule-helper.RuleHelper"></a>
+####textlint-rule-helper.RuleHelper → <code>RuleHelper</code>
+Exposes the RuleHelper class
+
+<a name="module_textlint-rule-helper..RuleHelper"></a>
+####class: textlint-rule-helper~RuleHelper
+
+* [class: ~RuleHelper](#module_textlint-rule-helper..RuleHelper)
+  * [new RuleHelper()](#new_module_textlint-rule-helper..RuleHelper_new)
+  * _instance_
+    * [.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>[Array.&lt;TxtNode&gt;](https://github.com/azu/textlint)</code>
+    * [.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
+
+<a name="new_module_textlint-rule-helper..RuleHelper_new"></a>
+#####new RuleHelper()
+RuleHelper is helper class for textlint.
+
+<a name="module_textlint-rule-helper..RuleHelper#getParents"></a>
+#####ruleHelper.getParents(node) ⇒ <code>[Array.&lt;TxtNode&gt;](https://github.com/azu/textlint)</code>
+Get parents of node.
+The parent nodes are returned in order from the closest parent to the outer ones.
+[node](node) is not contained in the results.
+
+| Param | Type | Description |
+| ----- | ---- | ----------- |
+| node | <code>[TxtNode](https://github.com/azu/textlint)</code> | the node is start point. |
+
+<a name="module_textlint-rule-helper..RuleHelper#isChildNode"></a>
+#####ruleHelper.isChildNode(node, types) ⇒ <code>boolean</code>
+Return true if `node` is wrapped any one of node [types](types).
+
+| Param | Type | Description |
+| ----- | ---- | ----------- |
+| node | <code>[TxtNode](https://github.com/azu/textlint)</code> | is target node |
+| types | <code>Array.&lt;string&gt;</code> | are wrapped target node |
+
+
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -12,62 +12,37 @@ npm install textlint-rule-helper
 
 
   <a name="RuleHelper"></a>
-####class: RuleHelper
-**Members**
+###class: RuleHelper
 
 * [class: RuleHelper](#RuleHelper)
-  * [new RuleHelper()](#new_RuleHelper)
-  * [ruleHelper.getParents(node)](#RuleHelper#getParents)
-  * [ruleHelper.isChildNode(node, types)](#RuleHelper#isChildNode)
+  * [new RuleHelper()](#new_RuleHelper_new)
+  * _instance_
+    * [.getParents(node)](#RuleHelper#getParents) ⇒ <code>Array.&lt;TxtNode&gt;</code>
+    * [.isChildNode(node, types)](#RuleHelper#isChildNode) ⇒ <code>boolean</code>
 
-<a name="new_RuleHelper"></a>
-#####new RuleHelper()
+<a name="new_RuleHelper_new"></a>
+####new RuleHelper()
 RuleHelper is helper class for textlint.
 
 <a name="RuleHelper#getParents"></a>
-#####ruleHelper.getParents(node)
+####ruleHelper.getParents(node) ⇒ <code>Array.&lt;TxtNode&gt;</code>
 Get parents of node.
 The parent nodes are returned in order from the closest parent to the outer ones.
-`node` is not contained in the results.
+[node](node) is not contained in the results.
 
-**Params**
+| Param | Type | Description |
+| ----- | ---- | ----------- |
+| node | <code>TxtNode</code> | the node is start point. |
 
-- node `TxtNode` - the node is start point.  
-
-**Returns**: `Array.<TxtNode>`  
 <a name="RuleHelper#isChildNode"></a>
-#####ruleHelper.isChildNode(node, types)
-Return true if `node` is wrapped any one of node `types`.
+####ruleHelper.isChildNode(node, types) ⇒ <code>boolean</code>
+Return true if `node` is wrapped any one of node [types](types).
 
-**Params**
+| Param | Type | Description |
+| ----- | ---- | ----------- |
+| node | <code>TxtNode</code> | is target node |
+| types | <code>Array.&lt;string&gt;</code> | are wrapped target node |
 
-- node `TxtNode` - is target node  
-- types `Array.<string>` - are wrapped target node  
-
-**Returns**: `boolean`  
-
-  <a name="RuleHelper#getParents"></a>
-####ruleHelper.getParents(node)
-Get parents of node.
-The parent nodes are returned in order from the closest parent to the outer ones.
-`node` is not contained in the results.
-
-**Params**
-
-- node `TxtNode` - the node is start point.  
-
-**Returns**: `Array.<TxtNode>`  
-
-  <a name="RuleHelper#isChildNode"></a>
-####ruleHelper.isChildNode(node, types)
-Return true if `node` is wrapped any one of node `types`.
-
-**Params**
-
-- node `TxtNode` - is target node  
-- types `Array.<string>` - are wrapped target node  
-
-**Returns**: `boolean`  
 
 
 

--- a/README.md
+++ b/README.md
@@ -11,21 +11,35 @@ npm install textlint-rule-helper
 ## Usage - API
 
 
-  <a name="RuleHelper"></a>
-###class: RuleHelper
+  <a name="module_textlint-rule-helper"></a>
+###textlint-rule-helper
+**Example**  
+```js
+var RuleHelper = require("textlint-rule-helper").RuleHelper;
+```
 
-* [class: RuleHelper](#RuleHelper)
-  * [new RuleHelper()](#new_RuleHelper_new)
+* [textlint-rule-helper](#module_textlint-rule-helper)
+  * [class: ~RuleHelper](#module_textlint-rule-helper..RuleHelper)
+    * [new RuleHelper()](#new_module_textlint-rule-helper..RuleHelper_new)
+    * _instance_
+      * [.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>Array.&lt;TxtNode&gt;</code>
+      * [.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
+
+<a name="module_textlint-rule-helper..RuleHelper"></a>
+####class: textlint-rule-helper~RuleHelper
+
+* [class: ~RuleHelper](#module_textlint-rule-helper..RuleHelper)
+  * [new RuleHelper()](#new_module_textlint-rule-helper..RuleHelper_new)
   * _instance_
-    * [.getParents(node)](#RuleHelper#getParents) ⇒ <code>Array.&lt;TxtNode&gt;</code>
-    * [.isChildNode(node, types)](#RuleHelper#isChildNode) ⇒ <code>boolean</code>
+    * [.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>Array.&lt;TxtNode&gt;</code>
+    * [.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
 
-<a name="new_RuleHelper_new"></a>
-####new RuleHelper()
+<a name="new_module_textlint-rule-helper..RuleHelper_new"></a>
+#####new RuleHelper()
 RuleHelper is helper class for textlint.
 
-<a name="RuleHelper#getParents"></a>
-####ruleHelper.getParents(node) ⇒ <code>Array.&lt;TxtNode&gt;</code>
+<a name="module_textlint-rule-helper..RuleHelper#getParents"></a>
+#####ruleHelper.getParents(node) ⇒ <code>Array.&lt;TxtNode&gt;</code>
 Get parents of node.
 The parent nodes are returned in order from the closest parent to the outer ones.
 [node](node) is not contained in the results.
@@ -34,8 +48,8 @@ The parent nodes are returned in order from the closest parent to the outer ones
 | ----- | ---- | ----------- |
 | node | <code>TxtNode</code> | the node is start point. |
 
-<a name="RuleHelper#isChildNode"></a>
-####ruleHelper.isChildNode(node, types) ⇒ <code>boolean</code>
+<a name="module_textlint-rule-helper..RuleHelper#isChildNode"></a>
+#####ruleHelper.isChildNode(node, types) ⇒ <code>boolean</code>
 Return true if `node` is wrapped any one of node [types](types).
 
 | Param | Type | Description |

--- a/README.md
+++ b/README.md
@@ -33,11 +33,10 @@ module.exports = function (context) {
 ```
 
 * [textlint-rule-helper](#module_textlint-rule-helper)
-  * [.RuleHelper](#module_textlint-rule-helper.RuleHelper) → <code>RuleHelper</code>
-  * [class: ~RuleHelper](#module_textlint-rule-helper..RuleHelper)
+  * class: [.RuleHelper](#module_textlint-rule-helper..RuleHelper)
     * [new RuleHelper()](#new_module_textlint-rule-helper..RuleHelper_new)
-    * [ruleHelper.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>[Array.&lt;TxtNode&gt;](https://github.com/azu/textlint)</code>
-    * [ruleHelper.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
+      * [.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>[Array.&lt;TxtNode&gt;](https://github.com/azu/textlint)</code>
+      * [.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
 
 <a name="module_textlint-rule-helper.RuleHelper"></a>
 ####textlint-rule-helper.RuleHelper → <code>RuleHelper</code>

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ module.exports = function (context) {
     return exports;
 }
 ```
+
 * [textlint-rule-helper](#module_textlint-rule-helper)
-  * [textlint-rule-helper.RuleHelper](#module_textlint-rule-helper.RuleHelper) → <code>RuleHelper</code>
-  * [class: textlint-rule-helper~RuleHelper](#module_textlint-rule-helper..RuleHelper)
+  * [.RuleHelper](#module_textlint-rule-helper.RuleHelper) → <code>RuleHelper</code>
+  * [class: ~RuleHelper](#module_textlint-rule-helper..RuleHelper)
     * [new RuleHelper()](#new_module_textlint-rule-helper..RuleHelper_new)
     * [ruleHelper.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>[Array.&lt;TxtNode&gt;](https://github.com/azu/textlint)</code>
     * [ruleHelper.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
@@ -44,7 +45,8 @@ Exposes the RuleHelper class
 
 <a name="module_textlint-rule-helper..RuleHelper"></a>
 ####class: textlint-rule-helper~RuleHelper
-* [class: textlint-rule-helper~RuleHelper](#module_textlint-rule-helper..RuleHelper)
+
+* [class: ~RuleHelper](#module_textlint-rule-helper..RuleHelper)
   * [new RuleHelper()](#new_module_textlint-rule-helper..RuleHelper_new)
   * [ruleHelper.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>[Array.&lt;TxtNode&gt;](https://github.com/azu/textlint)</code>
   * [ruleHelper.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>

--- a/README.md
+++ b/README.md
@@ -31,14 +31,12 @@ module.exports = function (context) {
     return exports;
 }
 ```
-
 * [textlint-rule-helper](#module_textlint-rule-helper)
-  * [.RuleHelper](#module_textlint-rule-helper.RuleHelper) → <code>RuleHelper</code>
-  * [class: ~RuleHelper](#module_textlint-rule-helper..RuleHelper)
+  * [textlint-rule-helper.RuleHelper](#module_textlint-rule-helper.RuleHelper) → <code>RuleHelper</code>
+  * [class: textlint-rule-helper~RuleHelper](#module_textlint-rule-helper..RuleHelper)
     * [new RuleHelper()](#new_module_textlint-rule-helper..RuleHelper_new)
-    * _instance_
-      * [.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>[Array.&lt;TxtNode&gt;](https://github.com/azu/textlint)</code>
-      * [.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
+    * [ruleHelper.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>[Array.&lt;TxtNode&gt;](https://github.com/azu/textlint)</code>
+    * [ruleHelper.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
 
 <a name="module_textlint-rule-helper.RuleHelper"></a>
 ####textlint-rule-helper.RuleHelper → <code>RuleHelper</code>
@@ -46,12 +44,10 @@ Exposes the RuleHelper class
 
 <a name="module_textlint-rule-helper..RuleHelper"></a>
 ####class: textlint-rule-helper~RuleHelper
-
-* [class: ~RuleHelper](#module_textlint-rule-helper..RuleHelper)
+* [class: textlint-rule-helper~RuleHelper](#module_textlint-rule-helper..RuleHelper)
   * [new RuleHelper()](#new_module_textlint-rule-helper..RuleHelper_new)
-  * _instance_
-    * [.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>[Array.&lt;TxtNode&gt;](https://github.com/azu/textlint)</code>
-    * [.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
+  * [ruleHelper.getParents(node)](#module_textlint-rule-helper..RuleHelper#getParents) ⇒ <code>[Array.&lt;TxtNode&gt;](https://github.com/azu/textlint)</code>
+  * [ruleHelper.isChildNode(node, types)](#module_textlint-rule-helper..RuleHelper#isChildNode) ⇒ <code>boolean</code>
 
 <a name="new_module_textlint-rule-helper..RuleHelper_new"></a>
 #####new RuleHelper()

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "6to5 src --out-dir lib  --source-maps-inline",
     "watch": "6to5 src --out-dir lib --watch --source-maps-inline",
-    "docs": "jsdoc2md -t template/README.template.md lib/textlint-rule-helper.js > README.md",
+    "docs": "jsdoc2md -c list -t template/README.template.md lib/textlint-rule-helper.js > README.md",
     "test": "npm run build && mocha test/*.js"
   },
   "directories": {

--- a/src/textlint-rule-helper.js
+++ b/src/textlint-rule-helper.js
@@ -1,8 +1,15 @@
 // LICENSE : MIT
 "use strict";
 /**
+@module textlint-rule-helper
+@example
+var RuleHelper = require("textlint-rule-helper").RuleHelper;
+*/
+
+/**
  * RuleHelper is helper class for textlint.
  * @class RuleHelper
+ * @alias module:textlint-rule-helper
  */
 export class RuleHelper {
     /**

--- a/src/textlint-rule-helper.js
+++ b/src/textlint-rule-helper.js
@@ -3,13 +3,30 @@
 /**
 @module textlint-rule-helper
 @example
+A rule for [textlint](https://github.com/azu/textlint "textlint").
+
+```js
 var RuleHelper = require("textlint-rule-helper").RuleHelper;
+module.exports = function (context) {
+    var helper = new RuleHelper(context);
+    var exports = {}
+    exports[context.Syntax.Str] = function(node){
+        // parent nodes is any one Link or Image.
+        if(helper.isChildNode(node, [context.Syntax.Link, context.Syntax.Image]){
+            return;
+        }
+        // get Parents
+        var parents = helper.getParents(node);
+        
+    }
+    return exports;
+}
+```
 */
 
 /**
  * RuleHelper is helper class for textlint.
  * @class RuleHelper
- * @alias module:textlint-rule-helper
  */
 export class RuleHelper {
     /**
@@ -24,8 +41,8 @@ export class RuleHelper {
      * Get parents of node.
      * The parent nodes are returned in order from the closest parent to the outer ones.
      * {@link node} is not contained in the results.
-     * @param {TxtNode} node the node is start point.
-     * @returns {TxtNode[]}
+     * @param {external:TxtNode} node the node is start point.
+     * @returns {external:TxtNode[]}
      */
     getParents(node) {
         var result = [];
@@ -39,7 +56,7 @@ export class RuleHelper {
 
     /**
      * Return true if `node` is wrapped any one of node {@link types}.
-     * @param {TxtNode} node is target node
+     * @param {external:TxtNode} node is target node
      * @param {string[]} types are wrapped target node
      * @returns {boolean}
      */
@@ -55,3 +72,8 @@ export class RuleHelper {
         });
     }
 }
+
+/**
+@external TxtNode
+@see https://github.com/azu/textlint
+*/

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -10,10 +10,10 @@ npm install textlint-rule-helper
 
 ## Usage - API
 
-{{heading-depth-set 2~}}
-{{#this}}
-  {{>exported~}}
-{{/this}}
+{{optionSet "heading-depth" 3 ~}}
+{{#class name="RuleHelper"}}
+  {{>docs~}}
+{{/class}}
 
 
 ## Example

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -11,9 +11,9 @@ npm install textlint-rule-helper
 ## Usage - API
 
 {{optionSet "heading-depth" 3 ~}}
-{{#class name="RuleHelper"}}
+{{#module name="textlint-rule-helper"}}
   {{>docs~}}
-{{/class}}
+{{/module}}
 
 
 ## Example

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -12,31 +12,9 @@ npm install textlint-rule-helper
 
 {{optionSet "heading-depth" 3 ~}}
 {{#module name="textlint-rule-helper"}}
-  {{>docs~}}
+  {{>docs skip-header=true ~}}
 {{/module}}
 
-
-## Example
-
-A rule for [textlint](https://github.com/azu/textlint "textlint").
-
-```js
-var RuleHelper = require("textlint-rule-helper").RuleHelper;
-module.exports = function (context) {
-    var helper = new RuleHelper(context);
-    var exports = {}
-    exports[context.Syntax.Str] = function(node){
-        // parent nodes is any one Link or Image.
-        if(helper.isChildNode(node, [context.Syntax.Link, context.Syntax.Image]){
-            return;
-        }
-        // get Parents
-        var parents = helper.getParents(node);
-        
-    }
-    return exports;
-}
-```
 
 ## Development
 


### PR DESCRIPTION
hey @azu .. this is not a serious PR, i just wanted to get some feedback from you.. 

i have generated your project README using the next version of jsdoc-to-markdown, what do you think? How can we improve it? 

you can see the new README here: https://github.com/75lb/textlint-rule-helper

the code changes i made are visible in this PR.. 

Install the preview release:
`$ npm install -g jsdoc-to-markdown@next`

try it for yourself: 
`$ jsdoc2md -t template/README.template.md lib/textlint-rule-helper.js`

take a look at the new options:
`$ jsdoc2md --help`
